### PR TITLE
Add ballerina/os version in Dependencies.toml

### DIFF
--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -23,4 +23,7 @@ org = "ballerina"
 name = "log"
 version = "1.1.0-alpha7"
 
-
+[[dependency]]
+org = "ballerina"
+name = "os"
+version = "1.1.0-alpha7"


### PR DESCRIPTION
## Purpose
Add ballerina/os version in Dependencies.toml to fix the CI build failure

## Goals
> Fix CI Build failure

## Approach
> Add ballerina/os version in Dependencies.toml

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes