### PR TITLE
Use HTTP 1.1 and Make proxy as nillable in ClientHttp1Settings

### DIFF
--- a/gpeople/config-types.bal
+++ b/gpeople/config-types.bal
@@ -20,7 +20,7 @@ public type ConnectionConfig record {|
     # Configurations related to client authentication
     BearerTokenConfig|OAuth2RefreshTokenGrantConfig auth;
     # The HTTP version understood by the client
-    HttpVersion httpVersion = HTTP_V2_0;
+    HttpVersion httpVersion = HTTP_V1_1;
     # Configurations related to HTTP/1.x protocol
     ClientHttp1Settings http1Settings = {};
     # Configurations related to HTTP/2 protocol
@@ -242,7 +242,7 @@ public type CertKey record {|
 public type ClientHttp1Settings record {|
     KeepAlive keepAlive = KEEPALIVE_AUTO;
     Chunking chunking = CHUNKING_AUTO;
-    ProxyConfig proxy = {};
+    ProxyConfig proxy?;
 |};
 
 # Defines the possible values for the keep-alive configuration in service and client endpoints.

--- a/gpeople/endpoint.bal
+++ b/gpeople/endpoint.bal
@@ -36,7 +36,7 @@ public isolated client class Client {
         http:ClientConfiguration httpClientConfig = {
             auth: config.auth,
             httpVersion: config.httpVersion,
-            http1Settings: config.http1Settings,
+            http1Settings: {...config.http1Settings},
             http2Settings: config.http2Settings,
             timeout: config.timeout,
             forwarded: config.forwarded,


### PR DESCRIPTION
# Description
- Use HTTP 1.1
- Make proxy as nillable in ClientHttp1Settings